### PR TITLE
Add missing unit tests

### DIFF
--- a/src/test/java/com/passwordmanager/auth/UserAuthTest.java
+++ b/src/test/java/com/passwordmanager/auth/UserAuthTest.java
@@ -1,0 +1,45 @@
+package com.passwordmanager.auth;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserAuthTest {
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Files.deleteIfExists(Path.of("master_user.json"));
+        Field keyField = UserAuth.class.getDeclaredField("encryptionKey");
+        keyField.setAccessible(true);
+        keyField.set(null, null);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        Files.deleteIfExists(Path.of("master_user.json"));
+    }
+
+    @Test
+    void testRegisterAndLogin() {
+        assertTrue(UserAuth.register("tester", "secret"));
+        assertTrue(UserAuth.login("tester", "secret"));
+        assertNotNull(UserAuth.getEncryptionKey());
+    }
+
+    @Test
+    void testLoginWrongPassword() {
+        UserAuth.register("tester", "secret");
+        assertFalse(UserAuth.login("tester", "wrong"));
+    }
+
+    @Test
+    void testLoginWithoutUserFile() {
+        assertFalse(UserAuth.login("none", "nopass"));
+    }
+}

--- a/src/test/java/com/passwordmanager/database/PasswordTest.java
+++ b/src/test/java/com/passwordmanager/database/PasswordTest.java
@@ -38,7 +38,7 @@ class PasswordTest {
     // Test für die toString-Methode (wobei das Passwort nicht ausgegeben wird)
     @Test
     void testToString() {
-        String expectedOutput = "Password{site='example.com', username='user1'}";
+        String expectedOutput = "Password{site='example.com', username='user1', password='***** (verschluesselt)'}";
         assertEquals(expectedOutput, password.toString());
     }
 }

--- a/src/test/java/com/passwordmanager/encryption/EncryptionUtilsTest.java
+++ b/src/test/java/com/passwordmanager/encryption/EncryptionUtilsTest.java
@@ -1,0 +1,40 @@
+package com.passwordmanager.encryption;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EncryptionUtilsTest {
+
+    @Test
+    void testEncryptAndDecrypt() throws Exception {
+        String key = Base64.getEncoder().encodeToString(EncryptionUtils.hashSHA256("secret"));
+        String text = "Hallo Welt";
+        String encrypted = EncryptionUtils.encrypt(text, key);
+        assertNotNull(encrypted);
+        String decrypted = EncryptionUtils.decrypt(encrypted, key);
+        assertEquals(text, decrypted);
+    }
+
+    @Test
+    void testDecryptWithWrongKeyThrows() throws Exception {
+        String key = Base64.getEncoder().encodeToString(EncryptionUtils.hashSHA256("secret"));
+        String otherKey = Base64.getEncoder().encodeToString(EncryptionUtils.hashSHA256("wrong"));
+        String encrypted = EncryptionUtils.encrypt("abc", key);
+        assertThrows(Exception.class, () -> EncryptionUtils.decrypt(encrypted, otherKey));
+    }
+
+    @Test
+    void testGenerateSecureRandomBytes() {
+        byte[] bytes = EncryptionUtils.generateSecureRandomBytes(16);
+        assertEquals(16, bytes.length);
+    }
+
+    @Test
+    void testHashSHA256() {
+        byte[] hash = EncryptionUtils.hashSHA256("test");
+        assertEquals(32, hash.length);
+    }
+}

--- a/src/test/java/com/passwordmanager/utils/PasswordGeneratorTest.java
+++ b/src/test/java/com/passwordmanager/utils/PasswordGeneratorTest.java
@@ -1,0 +1,26 @@
+package com.passwordmanager.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PasswordGeneratorTest {
+
+    @Test
+    void testGenerateValidPassword() {
+        String pw = PasswordGenerator.generate(10, true, true, true, true);
+        assertEquals(10, pw.length());
+    }
+
+    @Test
+    void testGenerateTooShortThrows() {
+        assertThrows(IllegalArgumentException.class,
+                () -> PasswordGenerator.generate(3, true, true, false, false));
+    }
+
+    @Test
+    void testGenerateWithNoCharTypesThrows() {
+        assertThrows(IllegalArgumentException.class,
+                () -> PasswordGenerator.generate(10, false, false, false, false));
+    }
+}


### PR DESCRIPTION
## Summary
- provide unit tests for `UserAuth`, `EncryptionUtils`, and `PasswordGenerator`
- fix failing expectation in `PasswordTest`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6)*

------
https://chatgpt.com/codex/tasks/task_e_68643b90e18483308e15b3cd9d20c2f0