### PR TITLE
Fix tests with temp files and mocks

### DIFF
--- a/src/main/java/com/passwordmanager/auth/UserAuth.java
+++ b/src/main/java/com/passwordmanager/auth/UserAuth.java
@@ -12,14 +12,19 @@ import java.util.Base64;
 import java.util.Scanner;
 
 public class UserAuth {
-    private static final String FILE_PATH = "master_user.json";
+    private static String filePath = "master_user.json";
     private static final Gson gson = new Gson();
     private static String encryptionKey;  // Abgeleiteter Schlüssel aus dem Master-Passwort
+
+    // Ermöglicht Tests einen eigenen Speicherort zu setzen
+    public static void setFilePath(String path) {
+        filePath = path;
+    }
 
     public static boolean login() {
         Scanner scanner = new Scanner(System.in);
 
-        if (!Files.exists(Paths.get(FILE_PATH))) {
+        if (!Files.exists(Paths.get(filePath))) {
             System.out.println("🔑 Kein Benutzer gefunden. Registrierung erforderlich.");
             return register();
         }
@@ -34,12 +39,12 @@ public class UserAuth {
     }
 
     public static boolean login(String username, String password) {
-        if (!Files.exists(Paths.get(FILE_PATH))) {
+        if (!Files.exists(Paths.get(filePath))) {
             return false;
         }
 
         try {
-            String json = Files.readString(Paths.get(FILE_PATH));
+            String json = Files.readString(Paths.get(filePath));
             JsonObject credentials = gson.fromJson(json, JsonObject.class);
 
             String savedUsername = credentials.get("username").getAsString();
@@ -80,7 +85,7 @@ public class UserAuth {
         credentials.addProperty("salt", salt);
 
         try {
-            Files.write(Paths.get(FILE_PATH), gson.toJson(credentials).getBytes(StandardCharsets.UTF_8));
+            Files.write(Paths.get(filePath), gson.toJson(credentials).getBytes(StandardCharsets.UTF_8));
             encryptionKey = deriveKeyFromMasterPassword(password, salt);
             return true;
         } catch (Exception e) {

--- a/src/main/java/com/passwordmanager/storage/PasswordStore.java
+++ b/src/main/java/com/passwordmanager/storage/PasswordStore.java
@@ -14,10 +14,15 @@ import java.util.List;
 
 public class PasswordStore {
     private List<Password> passwords;
-    private final String FILE_PATH = "passwords.json"; // Speicherort der Datei
+    private String filePath = "passwords.json"; // Speicherort der Datei
     private final Gson gson = new Gson();
 
     public PasswordStore() {
+        this("passwords.json");
+    }
+
+    public PasswordStore(String filePath) {
+        this.filePath = filePath;
         this.passwords = new ArrayList<>(); // Stelle sicher, dass passwords initialisiert wird
         loadFromFile(); // Gespeicherte Passwörter laden
     }
@@ -73,7 +78,7 @@ public class PasswordStore {
     }
 
     private void saveToFile() {
-        try (FileWriter writer = new FileWriter(FILE_PATH)) {
+        try (FileWriter writer = new FileWriter(filePath)) {
             gson.toJson(passwords, writer);
         } catch (IOException e) {
             System.err.println("Fehler beim Speichern der Passwörter: " + e.getMessage());
@@ -83,12 +88,12 @@ public class PasswordStore {
     private void loadFromFile() {
         passwords = new ArrayList<>(); // Immer eine neue Liste initialisieren
 
-        File file = new File(FILE_PATH);
+        File file = new File(filePath);
         if (!file.exists()) {
             return; // Falls Datei nicht existiert, bleibt die Liste leer
         }
 
-        try (FileReader reader = new FileReader(FILE_PATH)) {
+        try (FileReader reader = new FileReader(filePath)) {
             Type listType = new TypeToken<ArrayList<Password>>() {}.getType();
             List<Password> loadedPasswords = gson.fromJson(reader, listType);
             if (loadedPasswords != null) {

--- a/src/test/java/com/passwordmanager/auth/UserAuthTest.java
+++ b/src/test/java/com/passwordmanager/auth/UserAuthTest.java
@@ -7,14 +7,17 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class UserAuthTest {
+    private Path tempFile;
 
     @BeforeEach
     void setUp() throws Exception {
-        Files.deleteIfExists(Path.of("master_user.json"));
+        tempFile = Files.createTempFile("userauth", ".json");
+        UserAuth.setFilePath(tempFile.toString());
         Field keyField = UserAuth.class.getDeclaredField("encryptionKey");
         keyField.setAccessible(true);
         keyField.set(null, null);
@@ -22,7 +25,8 @@ class UserAuthTest {
 
     @AfterEach
     void tearDown() throws Exception {
-        Files.deleteIfExists(Path.of("master_user.json"));
+        Files.deleteIfExists(tempFile);
+        UserAuth.setFilePath("master_user.json");
     }
 
     @Test

--- a/src/test/java/com/passwordmanager/database/PasswordTest.java
+++ b/src/test/java/com/passwordmanager/database/PasswordTest.java
@@ -1,7 +1,11 @@
 package com.passwordmanager.database;
 
+import com.passwordmanager.auth.UserAuth;
+import com.passwordmanager.encryption.EncryptionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import java.lang.reflect.Field;
+import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -11,7 +15,11 @@ class PasswordTest {
 
     // Setup-Methode, die vor jedem Test aufgerufen wird
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
+        String key = Base64.getEncoder().encodeToString(EncryptionUtils.hashSHA256("secret"));
+        Field keyField = UserAuth.class.getDeclaredField("encryptionKey");
+        keyField.setAccessible(true);
+        keyField.set(null, key);
         password = new Password("example.com", "user1", "securepassword123");
     }
 

--- a/src/test/java/com/passwordmanager/storage/PasswordStoreTest.java
+++ b/src/test/java/com/passwordmanager/storage/PasswordStoreTest.java
@@ -21,17 +21,15 @@ class PasswordStoreTest {
     // Setup-Methode, die vor jedem Test ausgeführt wird
     @BeforeEach
     void setUp() {
-        passwordStore = new PasswordStore();
-        password1 = new Password("example.com", "user1", "securepassword123");
-        password2 = new Password("testsite.com", "user2", "password456");
-
-        // Erstellen einer temporären Datei für Speichern und Laden von Passwörtern
         try {
             Path tempFile = Files.createTempFile("passwords", ".json");
             tempFilePath = tempFile.toString();
+            passwordStore = new PasswordStore(tempFilePath);
         } catch (Exception e) {
             e.printStackTrace();
         }
+        password1 = new Password("example.com", "user1", "securepassword123");
+        password2 = new Password("testsite.com", "user2", "password456");
     }
 
     // Test für das Hinzufügen eines Passworts
@@ -80,7 +78,7 @@ class PasswordStoreTest {
         passwordStore.savePasswordsToFile(tempFilePath);
 
         // Neues PasswordStore-Objekt erstellen und Passwörter laden
-        PasswordStore newPasswordStore = new PasswordStore();
+        PasswordStore newPasswordStore = new PasswordStore(tempFilePath);
         newPasswordStore.loadPasswordsFromFile(tempFilePath);
 
         assertEquals(2, newPasswordStore.getAllPasswords().size());


### PR DESCRIPTION
## Summary
- allow custom user file path for `UserAuth`
- make `PasswordStore` accept custom storage path
- update tests to use temporary files and mocked encryption key

## Testing
- `mvn -q test` *(fails: Plugin resolution from repo.maven.apache.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68643cfa58288330b77ba2fcf156d662